### PR TITLE
Play nice with other packages that autoload

### DIFF
--- a/wp-cli-ssh.php
+++ b/wp-cli-ssh.php
@@ -28,7 +28,7 @@
 /**
  * Bail if not a WP-CLI request
  */
-if ( ! defined( 'WP_CLI_ROOT' ) ) {
+if ( ! defined( 'WP_CLI' ) ) {
         return;
 }
 


### PR DESCRIPTION
Since in the `composer.json` the autoload is set to files, it gets loaded in memory for [every time Composer sets up autoload](http://getcomposer.org/doc/04-schema.md#files).

When other installed packages require Composer's autoloader, this file get's included. The core of WP-CLI doesn't autoload anything unless the binary is called. The classes `WP_CLI_Command` and `WP_CLI` aren't available and leads to a fatal error

```
PHP Fatal error:  Class 'WP_CLI_Command' not found in [ABSPATH]/vendor/x-team/wp-cli-ssh/wp-cli-ssh.php on line 31
```

When inside a WP-CLI command, during the bootstrap, it defines 'WP_CLI_ROOT' [here](https://github.com/wp-cli/wp-cli/blob/master/php/boot-phar.php) or [here](https://github.com/wp-cli/wp-cli/blob/master/php/boot-fs.php). By testing for that constant and returning early, the fatal error can be prevented.
