### PR TITLE
Change required PHP version to >=5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"description": "Invoke WP-CLI on another server via SSH from local machine",
 	"homepage": "https://github.com/x-team/wp-cli-ssh",
 	"require": {
-		"wp-cli/wp-cli": ">=0.13"
+		"wp-cli/wp-cli": ">=0.13",
+		"php": ">=5.3"
 	},
 	"license": "GPLv2",
 	"keywords": ["wp-cli","ssh","remote"],
@@ -22,9 +23,6 @@
 			"role": "Developer"
 		}
 	],
-	"require": {
-		"php": ">=5.4"
-	},
 	"support": {
 		"issues": "https://github.com/x-team/wp-cli-ssh/issues",
 		"source": "https://github.com/x-team/wp-cli-ssh"


### PR DESCRIPTION
Our project maintains compatibility with PHP 5.3, we love `wp-cli-ssh`, but now we need to install it as a composer dependency.

The code is compatible with 5.3, so it should be OK to change the required version.
