### PR TITLE
Custom php interpreter support

### DIFF
--- a/wp-cli-ssh.php
+++ b/wp-cli-ssh.php
@@ -107,6 +107,7 @@ class WP_CLI_SSH_Command extends WP_CLI_Command {
 		// Check if a target is specified or fallback on local if not.
 		if ( ! isset( $assoc_args[$target_server] ) ){
 			// Run local wp cli command
+			WP_CLI::log( "Target host '" . $target_server . "' is not configured. Falling back on localhost." );
 			$php_bin = defined( 'PHP_BINARY' ) ? PHP_BINARY : getenv( 'WP_CLI_PHP_USED' );
 			$cmd = sprintf( '%s %s %s', $php_bin, $GLOBALS['argv'][0], implode( ' ', $cli_args ) );
 			passthru( $cmd, $exit_code );

--- a/wp-cli-ssh.php
+++ b/wp-cli-ssh.php
@@ -135,7 +135,7 @@ class WP_CLI_SSH_Command extends WP_CLI_Command {
 		$cmd = '
 			set -e;
 			if command -v wp >/dev/null 2>&1; then
-				wp_command=wp;
+				wp_command=$(command -v wp);
 			else
 				wp_command=/tmp/wp-cli.phar;
 				if [ ! -e $wp_command ]; then
@@ -144,8 +144,13 @@ class WP_CLI_SSH_Command extends WP_CLI_Command {
 				fi;
 			fi;
 			cd %s;
-			$wp_command
 		';
+
+    if ( isset( $ssh_config['php_interpreter'] ) ) {
+			$cmd .= escapeshellcmd( $ssh_config['php_interpreter'] ) . ' ';
+		}
+
+		$cmd .= '$wp_command';
 
 		// Replace path
 		$cmd = sprintf( $cmd, escapeshellarg( $path ) );

--- a/wp-cli-ssh.php
+++ b/wp-cli-ssh.php
@@ -132,8 +132,8 @@ class WP_CLI_SSH_Command extends WP_CLI_Command {
 		}
 
 		$cmd = 'set -e;';
-		if( isset( $ssh_config['wpcli_binary_path'] ) ) {
-			$cmd .= 'wp_command=' . escapeshellcmd( $ssh_config['wpcli_binary_path'] ) . ';';
+		if( isset( $ssh_config['wpcli_command'] ) ) {
+			$cmd .= 'wp_command=' . escapeshellcmd( $ssh_config['wpcli_command'] ) . ';';
 		} else {
 			// Inline bash script to detect or download wp-cli
 			$cmd .= '

--- a/wp-cli-ssh.php
+++ b/wp-cli-ssh.php
@@ -138,7 +138,7 @@ class WP_CLI_SSH_Command extends WP_CLI_Command {
 			// Inline bash script to detect or download wp-cli
 			$cmd .= '
 			if command -v wp >/dev/null 2>&1; then
-				wp_command=$(command -v wp);
+				wp_command=wp;
 			else
 				wp_command=/tmp/wp-cli.phar;
 				if [ ! -e $wp_command ]; then

--- a/wp-cli.sample.yml
+++ b/wp-cli.sample.yml
@@ -16,7 +16,7 @@ ssh:
     path: /var/www/staging.example.com/current/docroot
 
     # Use a custom php interpreter / wp-cli command on the remote server
-    wpcli_binary_path: php ./vendor/bin/wp
+    wpcli_command: php ./vendor/bin/wp
 
     # WP-CLI over SSH will stop if one of these are provided
     disabled_commands:

--- a/wp-cli.sample.yml
+++ b/wp-cli.sample.yml
@@ -15,6 +15,9 @@ ssh:
     # We cd to this path on the remote server before running WP-CLI
     path: /var/www/staging.example.com/current/docroot
 
+    # Use a custom php interpreter on the remote server
+    php_interpreter: php
+
     # WP-CLI over SSH will stop if one of these are provided
     disabled_commands:
       - db drop

--- a/wp-cli.sample.yml
+++ b/wp-cli.sample.yml
@@ -15,8 +15,8 @@ ssh:
     # We cd to this path on the remote server before running WP-CLI
     path: /var/www/staging.example.com/current/docroot
 
-    # Use a custom php interpreter on the remote server
-    php_interpreter: php
+    # Use a custom php interpreter / wp-cli command on the remote server
+    wpcli_binary_path: php ./vendor/bin/wp
 
     # WP-CLI over SSH will stop if one of these are provided
     disabled_commands:


### PR DESCRIPTION
Attempt at providing support for different php interpreters.
Uses a subshell at the moment. I'm not quite certain that that is the way to go in bash. But if you want to use wp-cli like: /usr/bin/php wp <wp-cli command>. you have to specify a file path like: /usr/bin/php /path/to/wp <wp-cli command>. Otherwise it will throw a no input file specified error.