### PR TITLE
Escape wpcli_command

### DIFF
--- a/wp-cli-ssh.php
+++ b/wp-cli-ssh.php
@@ -133,7 +133,7 @@ class WP_CLI_SSH_Command extends WP_CLI_Command {
 
 		$cmd = 'set -e;';
 		if( isset( $ssh_config['wpcli_command'] ) ) {
-			$cmd .= 'wp_command=' . escapeshellcmd( $ssh_config['wpcli_command'] ) . ';';
+			$cmd .= "wp_command='" . escapeshellcmd( $ssh_config['wpcli_command'] ) . "';";
 		} else {
 			// Inline bash script to detect or download wp-cli
 			$cmd .= '


### PR DESCRIPTION
Just noticed a bug when using the wpcli_command option. The command didn't go through because it looked like this:
`set -e;wp_command=php7 /usr/local/bin/wp;cd '/var/www/vhosts/isbijna.af/westerveld';$wp_command 'option' 'get' 'siteurl'`

which will assign `wp_command` to `php7` and execute /usr/local/bin/wp right after that.
This pull request will escape the command so it's formatted:

`set -e;wp_command='php7 /usr/local/bin/wp';cd '/var/www/vhosts/isbijna.af/westerveld';$wp_command 'option' 'get' 'siteurl'`
